### PR TITLE
Java9 init

### DIFF
--- a/java-9/Dockerfile
+++ b/java-9/Dockerfile
@@ -1,4 +1,8 @@
-FROM openjdk:9-jre-slim
+FROM openjdk:9-jdk-slim
+
+RUN apt-get update && apt-get install -y wget
+RUN wget -O /dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64
+RUN chmod +x /dumb-init
 
 ENV LC_ALL="no_NB.UTF-8"
 ENV LANG="no_NB.UTF-8"
@@ -13,4 +17,5 @@ WORKDIR /app
 
 EXPOSE 8080
 
-ENTRYPOINT ["/run-java.sh"]
+ENTRYPOINT ["/dumb-init"]
+CMD ["/run-java.sh"]

--- a/java-9/README.md
+++ b/java-9/README.md
@@ -37,5 +37,6 @@ and build using `docker build --build-arg JAR_FILE=my-awesome.jar`
 * Exposing port `8080`
 * `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap`
 * Main JAR file `/app/app.jar`
+* `app.jar` not running as PID 1
 
 Custom runtime options may be specified using the environment variable `JAVA_OPTS`.


### PR DESCRIPTION
Changed base from openjdk:9-jre-slim to openjdk:9-jdk slim to include dump utils.
Added dumb-init as entrypoint for run-java.sh. Fixes #2 for java-9.