### PR TITLE
Avoid backslash

### DIFF
--- a/java-10/init-scripts/02-import-env-files.sh
+++ b/java-10/init-scripts/02-import-env-files.sh
@@ -4,7 +4,7 @@ if test -d /var/run/secrets/nais.io/vault;
 then
     for FILE in /var/run/secrets/nais.io/vault/*.env
     do
-        for line in $(cat $FILE); do
+        for line in $(cat $FILE | sed 's/[\\]//g'); do
             echo "- exporting `echo $line | cut -d '=' -f 1`"
             export $line
         done

--- a/java-11/init-scripts/02-import-env-files.sh
+++ b/java-11/init-scripts/02-import-env-files.sh
@@ -4,7 +4,7 @@ if test -d /var/run/secrets/nais.io/vault;
 then
     for FILE in /var/run/secrets/nais.io/vault/*.env
     do
-        for line in $(cat $FILE); do
+        for line in $(cat $FILE | sed 's/[\\]//g'); do
             echo "- exporting `echo $line | cut -d '=' -f 1`"
             export $line
         done

--- a/java-8/init-scripts/02-import-env-files.sh
+++ b/java-8/init-scripts/02-import-env-files.sh
@@ -4,7 +4,7 @@ if test -d /var/run/secrets/nais.io/vault;
 then
     for FILE in /var/run/secrets/nais.io/vault/*.env
     do
-        for line in $(cat $FILE); do
+        for line in $(cat $FILE | sed 's/[\\]//g'); do
             echo "- exporting `echo $line | cut -d '=' -f 1`"
             export $line
         done


### PR DESCRIPTION
problem:  
when env file contains `"` in the value, Vault stores the file by adding backslah char as `\"` which includes unwanted char in the env-var value.