### PR TITLE
Make sure that the pipe symbol is escaped.

### DIFF
--- a/java-common/run-java.sh
+++ b/java-common/run-java.sh
@@ -1,9 +1,10 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 if test -f ./bin/${APP_BINARY};
 then
     # Gradle application plugin overwrites DEFAULT_JVM_OPTS
     JAVA_OPTS="${JAVA_OPTS} ${DEFAULT_JVM_OPTS}"
+    JAVA_OPTS=${JAVA_OPTS//\|/\\\|}
     set -x
     ./bin/${APP_BINARY} $@
 elif test -d "/app/WEB-INF";


### PR DESCRIPTION
The shell script that ./gradle installDist provides is re-evaluating the environment variables, which causes bash to think that the hostname separator is a shell pipe.
String replacement only works with bash, not sh, so the shell had to be changed as well.

This change must be coordinated with a change in naisd so that the proxy properties within JAVA_PROXY_OPTIONS is no longer quoted.