### PR TITLE
Improve backwards compability for AppDynamics

### DIFF
--- a/java-10/appdynamics/README.md
+++ b/java-10/appdynamics/README.md
@@ -8,11 +8,45 @@ Se README for Java 10 for general usage.
 
 ## Configuration of AppDynamics
 
+### Application name
 AppDynamics will automatically report itself by using the value of the
-environment variable `APP_NAME` as the Application name.
+environment variable `APPD_NAME` as the Application name.
 
-To use a different Application name in AppDynamics, the environment variable
-`APPD_NAME` can be set in your Dockerfile.
+```
+ENV APPD_NAME=my_app
+```
+
+The most generic way use this is to forward what NAIS injects as `APP_NAME`
+by adding the following to your Dockerfile:
+
+```
+ENV APPD_NAME=APP_NAME
+```
+
+The init-script will attempt to resolve the value of APPD_NAME as long as it
+references another environment variable.
+
+### Tier
+
+Tier will by default be the same as `APPD_NAME`. You can override this by
+setting the `APPD_TIER`, for example:
+
+```
+ENV APPD_TIER=backend
+```
+
+* If you want to use dynamic values, you'll have to move it to a separate
+  init-script that runs before `10-appdynamics.sh`.
+
+### Hostname
+
+You can also override the hostname by setting `APPD_HOSTNAME`, for example:
+
+```
+export APPD_HOSTNAME="$FASIT_ENVIRONMENT_NAME-$HOSTNAME"
+```
+
+As the hostname can't be static, it must be set with a init-script.
 
 ### Aggregating different tiers as one application
 

--- a/java-11/appdynamics/README.md
+++ b/java-11/appdynamics/README.md
@@ -8,11 +8,45 @@ Se README for Java 11 for general usage.
 
 ## Configuration of AppDynamics
 
+### Application name
 AppDynamics will automatically report itself by using the value of the
-environment variable `APP_NAME` as the Application name.
+environment variable `APPD_NAME` as the Application name.
 
-To use a different Application name in AppDynamics, the environment variable
-`APPD_NAME` can be set in your Dockerfile.
+```
+ENV APPD_NAME=my_app
+```
+
+The most generic way use this is to forward what NAIS injects as `APP_NAME`
+by adding the following to your Dockerfile:
+
+```
+ENV APPD_NAME=APP_NAME
+```
+
+The init-script will attempt to resolve the value of APPD_NAME as long as it
+references another environment variable.
+
+### Tier
+
+Tier will by default be the same as `APPD_NAME`. You can override this by
+setting the `APPD_TIER`, for example:
+
+```
+ENV APPD_TIER=backend
+```
+
+* If you want to use dynamic values, you'll have to move it to a separate
+  init-script that runs before `10-appdynamics.sh`.
+
+### Hostname
+
+You can also override the hostname by setting `APPD_HOSTNAME`, for example:
+
+```
+export APPD_HOSTNAME="$FASIT_ENVIRONMENT_NAME-$HOSTNAME"
+```
+
+As the hostname can't be static, it must be set with a init-script.
 
 ### Aggregating different tiers as one application
 

--- a/java-8/appdynamics/README.md
+++ b/java-8/appdynamics/README.md
@@ -8,11 +8,45 @@ Se README for Java 8 for general usage.
 
 ## Configuration of AppDynamics
 
+### Application name
 AppDynamics will automatically report itself by using the value of the
-environment variable `APP_NAME` as the Application name.
+environment variable `APPD_NAME` as the Application name.
 
-To use a different Application name in AppDynamics, the environment variable
-`APPD_NAME` can be set in your Dockerfile.
+```
+ENV APPD_NAME=my_app
+```
+
+The most generic way use this is to forward what NAIS injects as `APP_NAME`
+by adding the following to your Dockerfile:
+
+```
+ENV APPD_NAME=APP_NAME
+```
+
+The init-script will attempt to resolve the value of APPD_NAME as long as it
+references another environment variable.
+
+### Tier
+
+Tier will by default be the same as `APPD_NAME`. You can override this by
+setting the `APPD_TIER`, for example:
+
+```
+ENV APPD_TIER=backend
+```
+
+* If you want to use dynamic values, you'll have to move it to a separate
+  init-script that runs before `10-appdynamics.sh`.
+
+### Hostname
+
+You can also override the hostname by setting `APPD_HOSTNAME`, for example:
+
+```
+export APPD_HOSTNAME="$FASIT_ENVIRONMENT_NAME-$HOSTNAME"
+```
+
+As the hostname can't be static, it must be set with a init-script.
 
 ### Aggregating different tiers as one application
 

--- a/java-common/init-scripts/10-appdynamics.sh
+++ b/java-common/init-scripts/10-appdynamics.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
-if [ -r "/opt/appdynamics/javaagent.jar" ] && [ -n "${APP_NAME}" ]
+
+# If APPD_NAME is set to another variable, this resolves the referred value.
+# Otherwise it will use the value of APPD_NAME as is.
+APPD_NAME=$([ -z ${!APPD_NAME} ] && echo $APPD_NAME || echo ${!APPD_NAME})
+
+if [ -r "/opt/appdynamics/javaagent.jar" ] && [ -n "${APPD_NAME}" ]
 then
-    APPD_NAME="${APPD_NAME:-$APP_NAME}"
+    APPD_HOSTNAME="${APPD_HOSTNAME}"
     APPD_TIER="${APPD_TIER:-$APPD_NAME}"
 
     JAVA_OPTS="${JAVA_OPTS} -javaagent:/opt/appdynamics/javaagent.jar"
     JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.applicationName=${APPD_NAME}"
-    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.nodeName=prod-${HOSTNAME}"
-    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.tierName=prod-${APPD_TIER}"
+    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.nodeName=${APPD_HOSTNAME:-$HOSTNAME}"
+    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.tierName=${APPD_TIER}"
     export JAVA_OPTS
 fi


### PR DESCRIPTION
The current approach conflicts with everyone that has added their own
scripts. The behaviour will be very unpredictable.

This approach introduces a dedicated variable that must be set before
this script can be used. It can be set either in the Dockerfile or in
a earlier init-script.