### PR TITLE
Fix parsing of secrets *.env files that contain values with spaces

### DIFF
--- a/common/init-scripts/import-env-files.sh
+++ b/common/init-scripts/import-env-files.sh
@@ -4,14 +4,25 @@ if test -d /var/run/secrets/nais.io/vault;
 then
     for FILE in /var/run/secrets/nais.io/vault/*.env
     do
-        for line in $(cat $FILE); do
-            if test "${line#*=}" != "$line"
+        _oldIFS=$IFS
+        IFS='
+'
+        for line in $(cat "$FILE"); do
+            _key=${line%%=*}
+            _val=${line#*=}
+
+            if test "$_key" != "$line"
             then
-                echo "- exporting `echo $line | cut -d '=' -f 1`"
+                echo "- exporting $_key"
             else
                 echo "- (warn) exporting contents of $FILE which is not formatted as KEY=VALUE"
             fi
-            export $line
+
+            export "$_key"="$_val"
+
+            # more advanced alternative which also strips any quotes around var values:
+            #export "$_key"="$(echo "$_val"|sed -e "s/^['\"]//" -e "s/['\"]$//")"
         done
+        IFS=$_oldIFS
     done
 fi

--- a/common/init-scripts/import-env-files.sh
+++ b/common/init-scripts/import-env-files.sh
@@ -18,10 +18,7 @@ then
                 echo "- (warn) exporting contents of $FILE which is not formatted as KEY=VALUE"
             fi
 
-            export "$_key"="$_val"
-
-            # more advanced alternative which also strips any quotes around var values:
-            #export "$_key"="$(echo "$_val"|sed -e "s/^['\"]//" -e "s/['\"]$//")"
+            export "$_key"="$(echo "$_val"|sed -e "s/^['\"]//" -e "s/['\"]$//")"
         done
         IFS=$_oldIFS
     done

--- a/java-common/init-scripts/02-import-env-files.sh
+++ b/java-common/init-scripts/02-import-env-files.sh
@@ -4,14 +4,25 @@ if test -d /var/run/secrets/nais.io/vault;
 then
     for FILE in /var/run/secrets/nais.io/vault/*.env
     do
-        for line in $(cat $FILE); do
-            if test "${line#*=}" != "$line"
+        _oldIFS=$IFS
+        IFS='
+'
+        for line in $(cat "$FILE"); do
+            _key=${line%%=*}
+            _val=${line#*=}
+
+            if test "$_key" != "$line"
             then
-                echo "- exporting `echo $line | cut -d '=' -f 1`"
+                echo "- exporting $_key"
             else
                 echo "- (warn) exporting contents of $FILE which is not formatted as KEY=VALUE"
             fi
-            export $line
+
+            export "$_key"="$_val"
+
+            # more advanced alternative which also strips any quotes around var values:
+            #export "$_key"="$(echo "$_val"|sed -e "s/^['\"]//" -e "s/['\"]$//")"
         done
+        IFS=$_oldIFS
     done
 fi

--- a/java-common/init-scripts/02-import-env-files.sh
+++ b/java-common/init-scripts/02-import-env-files.sh
@@ -18,10 +18,7 @@ then
                 echo "- (warn) exporting contents of $FILE which is not formatted as KEY=VALUE"
             fi
 
-            export "$_key"="$_val"
-
-            # more advanced alternative which also strips any quotes around var values:
-            #export "$_key"="$(echo "$_val"|sed -e "s/^['\"]//" -e "s/['\"]$//")"
+            export "$_key"="$(echo "$_val"|sed -e "s/^['\"]//" -e "s/['\"]$//")"
         done
         IFS=$_oldIFS
     done

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,15 +3,18 @@
 
 test: jartest wartest
 
+volumes = -v $(CURDIR)/truststore.jts:/app/truststore.jts \
+          -v $(CURDIR)/secrets.env:/var/run/secrets/nais.io/vault/secrets.env
+
 jartest: jarbuild
-	docker run --rm --env-file test.env -v $(CURDIR)/truststore.jts:/app/truststore.jts test-jar-8
-	docker run --rm --env-file test.env -v $(CURDIR)/truststore.jts:/app/truststore.jts test-jar-10
-	docker run --rm --env-file test.env -v $(CURDIR)/truststore.jts:/app/truststore.jts test-jar-11
+	docker run --rm --env-file test.env $(volumes) test-jar-8
+	docker run --rm --env-file test.env $(volumes) test-jar-10
+	docker run --rm --env-file test.env $(volumes) test-jar-11
 
 wartest: warbuild
-	docker run --rm --env-file test.env -v $(CURDIR)/truststore.jts:/app/truststore.jts test-war-8
-	docker run --rm --env-file test.env -v $(CURDIR)/truststore.jts:/app/truststore.jts test-war-10
-	docker run --rm --env-file test.env -v $(CURDIR)/truststore.jts:/app/truststore.jts test-war-11
+	docker run --rm --env-file test.env $(volumes) test-war-8
+	docker run --rm --env-file test.env $(volumes) test-war-10
+	docker run --rm --env-file test.env $(volumes) test-war-11
 
 jarbuild: jar-8 jar-10 jar-11
 

--- a/test/secrets.env
+++ b/test/secrets.env
@@ -1,0 +1,6 @@
+SECRET1=secret1
+SECRET2=secret number two
+SECRET3='secret number three'
+SECRET4="secret number four"
+SECRET5='"Secret with literal quotes included"'
+SECRET6

--- a/test/secrets.env
+++ b/test/secrets.env
@@ -1,6 +1,7 @@
 SECRET1=secret1
 SECRET2=secret number two
-SECRET3='secret number three'
-SECRET4="secret number four"
-SECRET5='"Secret with literal quotes included"'
-SECRET6
+SECRET3=secret=number three
+SECRET4='secret number four'
+SECRET5="secret number five"
+SECRET6='"Secret with literal quotes included"'
+SECRET7

--- a/test/src/main/java/Main.java
+++ b/test/src/main/java/Main.java
@@ -64,9 +64,10 @@ public class Main {
     private static void testThatVaultSecretsAreInjected(Map<String,String> env) {
         test(env.get("SECRET1").equals("secret1"));
         test(env.get("SECRET2").equals("secret number two"));
-        test(env.get("SECRET3").equals("secret number three"));
+        test(env.get("SECRET3").equals("secret=number three"));
         test(env.get("SECRET4").equals("secret number four"));
-        test(env.get("SECRET5").equals("\"Secret with literal quotes included\""));
-        test(env.get("SECRET6").equals("SECRET6"));  // default for invalid env-entry w/missing value
+        test(env.get("SECRET5").equals("secret number five"));
+        test(env.get("SECRET6").equals("\"Secret with literal quotes included\""));
+        test(env.get("SECRET7").equals("SECRET7"));  // default for invalid env-entry w/missing value
     }
 }

--- a/test/src/main/java/Main.java
+++ b/test/src/main/java/Main.java
@@ -27,6 +27,7 @@ public class Main {
 
         testThatTruststoreIsInjected(env, props);
         testThatHttpProxyIsInjected(env, props);
+        testThatVaultSecretsAreInjected(env);
 
         System.out.println("Test OK");
     }
@@ -58,5 +59,14 @@ public class Main {
         test(props.getProperty("http.proxyPort").equals("1234"));
         test(props.getProperty("https.proxyPort").equals("1234"));
         test(props.getProperty("http.nonProxyHosts").equals("host1|host2|*.wildcard.local|*.local|foo"));
+    }
+
+    private static void testThatVaultSecretsAreInjected(Map<String,String> env) {
+        test(env.get("SECRET1").equals("secret1"));
+        test(env.get("SECRET2").equals("secret number two"));
+        test(env.get("SECRET3").equals("secret number three"));
+        test(env.get("SECRET4").equals("secret number four"));
+        test(env.get("SECRET5").equals("\"Secret with literal quotes included\""));
+        test(env.get("SECRET6").equals("SECRET6"));  // default for invalid env-entry w/missing value
     }
 }


### PR DESCRIPTION
Vi har en app eller to som skal over på naiserator der verdi for en Vault-hemmelighet inneholder mellomrom. Det ser ikke ut til at shell-script -koden for baseimage som skal parse + eksportere disse dataene håndterer slike tilfeller.

(Koden i denne pull-requesten inneholder et alternativ som også stripper quotes rundt variabel-verdier, men jeg vet ikke om det er ønskelig eller ei. Så det ligger bare som en kommentar.)

Endringene er ikke testet som del av Docker-bygg fra min side, jeg har kun testet selve shell-script-koden for å importere `/var/run/secrets/nais.io/vault/*.env`. 

Fra commit:

Allow any of the following var definitions in Vault env files to work as
expected:

```
SECRET0=bar
SECRET1=some secret here=nais
SECRET2=some other secret here
SECRET3
```

For `SECRET3` a warning is issued, and value will be set to key.

To parse these correctly, shell special variable `IFS` must be set to only split
on newlines before looping through the lines of secrets files. The variable is
restored between each parse to its original value, which is typically
`<space><tab><newline>`, so as to not affect any other shell script code.

Also contains a slightly more advanced alternative which strips any quotes
around variable values. This would allow the following env var definitions to also
work as one might expect:

```
SECRET4='quoted value, please strip quotes'
SECRET5="double quoted value, please strip quotes"
```

That is, the actual values exported to process environment would be:

```
SECRET4=quoted value, please strip quotes
SECRET5=double quoted value, please strip quotes
```