### PR TITLE
Added new Appdynamics agent file to support java 11

### DIFF
--- a/java-11/appdynamics/Dockerfile
+++ b/java-11/appdynamics/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian AS builder
 
-ENV APPD_AGENT_VERSION="4.5.4.24355"
-ENV APPD_AGENT_SHA256="b95378b5c6cd53630f503e97c636a7262839893b4f188edabb1d9529f6f54ef1"
+ENV APPD_AGENT_VERSION="4.5.10.25916"
+ENV APPD_AGENT_SHA256="713d8b26b24f201d16de84a9b8caa7df65b5ebeefa2d051d7d7bab4e9fb4f466"
 
 RUN apt-get update && apt-get install -y --no-install-recommends  unzip \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Appdynamics provided support for java 11 in  4.5.6.* versions of the java agent