### PR TITLE
Start the AppDynamics agent on naiserator apps

### DIFF
--- a/java-common/init-scripts/10-appdynamics.sh
+++ b/java-common/init-scripts/10-appdynamics.sh
@@ -2,9 +2,9 @@
 
 if [ -r "/opt/appdynamics/javaagent.jar" ] &&
     "${APPD_ENABLED}" == "true" &&
-    ([ -n "${APP_NAME}" ] || [ -n "${APPD_NAME}" ])
+    ([ -n "${APP_NAME}" ] || [ -n "${APPD_NAME}" ] || [ -n "${NAIS_APP_NAME}" ])
 then
-    APPD_NAME=${APPD_NAME:-$APP_NAME}
+    APPD_NAME=${APPD_NAME:-$APP_NAME:-$NAIS_APP_NAME}
     APPD_HOSTNAME="${APPD_HOSTNAME:-$HOSTNAME}"
     APPD_TIER="${APPD_TIER:-$APPD_NAME}"
 


### PR DESCRIPTION
Naiserator uses a different env variable for app name than naisd.