### PR TITLE
Don't start Redis if sourcing of values from Vault errored

### DIFF
--- a/node-express-12/Dockerfile
+++ b/node-express-12/Dockerfile
@@ -13,6 +13,8 @@ RUN mkdir -p /var/server
 
 WORKDIR /var/server
 
-RUN npm install -g express@4.16.3
+RUN npm config set unsafe-perm true \
+    && npm install -g express@4.16.3 \
+    && npm config set unsafe-perm false
 
 ENTRYPOINT ["/dumb-init", "--", "/entrypoint.sh"]

--- a/node-express-9/Dockerfile
+++ b/node-express-9/Dockerfile
@@ -13,6 +13,8 @@ RUN mkdir -p /var/server
 
 WORKDIR /var/server
 
-RUN npm install -g express@4.16.3
+RUN npm config set unsafe-perm true \
+    && npm install -g express@4.16.3 \
+    && npm config set unsafe-perm false
 
 ENTRYPOINT ["/dumb-init", "--", "/entrypoint.sh"]

--- a/redis/secure-redis/start.sh
+++ b/redis/secure-redis/start.sh
@@ -2,4 +2,9 @@
 
 source /var/run/secrets/nais.io/vault/redis.env
 
+[ -z "$REDIS_PASSWORD" ] && {
+    echo "Missing or empty value for REDIS_PASSWORD. Did you set it in Vault?"
+    exit 1
+}
+
 redis-server --requirepass "$REDIS_PASSWORD"


### PR DESCRIPTION
Without error handling the redis server will be started with a required
password of empty string, which has the same effects as not requiring a
password.