### PR TITLE
Use -storepass instead of reading from stdin

### DIFF
--- a/java-common/init-scripts/00-truststore.sh
+++ b/java-common/init-scripts/00-truststore.sh
@@ -2,7 +2,7 @@
 
 if test -r "${NAV_TRUSTSTORE_PATH}";
 then
-    if ! echo "${NAV_TRUSTSTORE_PASSWORD}" | keytool -list -keystore ${NAV_TRUSTSTORE_PATH} > /dev/null;
+    if ! keytool -list -keystore ${NAV_TRUSTSTORE_PATH} -storepass "${NAV_TRUSTSTORE_PASSWORD}" > /dev/null;
     then
         echo Truststore is corrupt, or bad password
         exit 1


### PR DESCRIPTION
This avoids printing of "Enter keystore password" to stderr during startup of containers.