### PR TITLE
Retter import-skript til å håndtere mer enn én ENV-fil

### DIFF
--- a/common/init-scripts/import-env-files.sh
+++ b/common/init-scripts/import-env-files.sh
@@ -1,8 +1,8 @@
 #!/bin/env sh
 
-if test -f /var/run/secrets/nais.io/vault/*.env;
+if test -d /var/run/secrets/nais.io/vault;
 then
-    for FILE in /var/run/secrets/nais.io/vault/*.env
+    find /var/run/secrets/nais.io/vault -type f -name "*.env" | while read -r FILE
     do
         _oldIFS=$IFS
         IFS='


### PR DESCRIPTION
`test -f` sammen med stjerne fører til at test mottar mer enn ett
argument, og det takler den ikke.