### PR TITLE
Riktig måte å eksportere variabler

### DIFF
--- a/common/init-scripts/import-env-files.sh
+++ b/common/init-scripts/import-env-files.sh
@@ -2,7 +2,7 @@
 
 if test -d /var/run/secrets/nais.io/vault;
 then
-    find /var/run/secrets/nais.io/vault -type f -name "*.env" | while read -r FILE
+    for FILE in $(find /var/run/secrets/nais.io/vault -maxdepth 1 -name "*.env")
     do
         _oldIFS=$IFS
         IFS='


### PR DESCRIPTION
Kan ikke exporte fra en pipe, da alt i en pipe foregår i et subshell.

Pakket koden inn i en funksjon for å unngå at variablen VAULT_FOLDER
eksponeres ut av skriptet.