### PR TITLE
Update Dockerfile

### DIFF
--- a/java/appdynamics/Dockerfile
+++ b/java/appdynamics/Dockerfile
@@ -1,6 +1,6 @@
 ARG java_version
 
-FROM appdynamics/java-agent:21.1.1 AS appdynamics
+FROM appdynamics/java-agent:21.6.0 AS appdynamics
 FROM navikt/java:common AS java-common
 FROM openjdk:${java_version}-slim
 


### PR DESCRIPTION
Changes the version for AppDynamics Java agent from 21.1.1 to 21.6.0.

Summary of new changes:
   - Support has been added for JDK16
   - Adds entry and exit support for Micronaut 2.0
   - Adds a new property to truncate the length of SQL statements
   
Full list of changes: [past-agent-releases](https://docs.appdynamics.com/21.6/en/product-and-release-announcements/past-releases/past-agent-releases#PastAgentReleases-JavaAgent)