### PR TITLE
Legge til ENV APPDYNAMICS_AGENT_BASE_DIR

### DIFF
--- a/java/appdynamics/Dockerfile
+++ b/java/appdynamics/Dockerfile
@@ -25,6 +25,7 @@ ENV APP_BINARY=app
 ENV APP_JAR=app.jar
 ENV MAIN_CLASS="Main"
 ENV CLASSPATH="/app/WEB-INF/classes:/app/WEB-INF/lib/*"
+ENV APPDYNAMICS_AGENT_BASE_DIR=/tmp/appdynamics
 
 WORKDIR /app
 


### PR DESCRIPTION
Overstyring av katalog for AppDynamics-agent - slik at den skriver til /tmp/appdynamics (og ikke får problemer med manglende rettigheter)