### PR TITLE
Mulighet for å trigge bygg og release manuelt

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,6 +6,7 @@ on:
       - master
   schedule:
     - cron: '22 22 * * 2'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Nytting når en kritisk oppdatering blir releaset. F.eks som i går med openssl som ubuntu og eclipse-temurin har patchet med en gang.