### PR TITLE
Kontrollerer sjekksummen

### DIFF
--- a/java-common/Dockerfile
+++ b/java-common/Dockerfile
@@ -1,6 +1,7 @@
 FROM busybox
 
 RUN wget -O /dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64
+RUN echo "057ecd4ac1d3c3be31f82fc0848bf77b1326a975b4f8423fe31607205a0fe945  /dumb-init" | sha256sum -c
 RUN chmod +x /dumb-init
 
 COPY init-scripts/ /init-scripts


### PR DESCRIPTION
Kontrollerer at sjekksummen på dumb-init som blir lasta ned med wget matchar med sjekksummen som ligg for den releasen på github, for å redusere risikoen for at dette wget-kallet gir oss ei anna fil enn den vi forventar