### PR TITLE
Revert "Add node 18 (#142)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ python_targets = $(addprefix python-, $(PYTHON_VERSIONS))
 JAVA_VERSIONS = 8 11 13 14 15 16 17 18
 java_targets = $(addprefix java-, $(JAVA_VERSIONS))
 
-NODE_VERSIONS = 9 12 14 16 18
+NODE_VERSIONS = 9 12 14 16
 node_targets = $(addprefix node-, $(NODE_VERSIONS))
 
 .PHONY: all java node python common $(java_targets) java-8-fat $(node_targets) $(python_targets) wildfly-17

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project contains base docker images for use with the NAIS platform.
 
 Available images from Dockerhub:
 * JDK 8 and 11 - 18 ([`java`](java)) - (`ALL versions deprecated/unsupported, should NOT be used`)
-* Node 9, 12, 14, 16 and 18 with Express 4 ([`node-express`](node-express)) (`9, 12 & 14 are deprecated`)
+* Node 9, 12, 14 and 16 with Express 4 ([`node-express`](node-express)) (`9, 12 & 14 are deprecated`)
 * Python 3.7, 3.8 and 3.9 ([`python`](python))
 
 Available images from Github Container Registry:


### PR DESCRIPTION
This reverts commit c90fc0eebc17d159d75df85d748b601be13cd95d.

Dette feilet på: `unsafe-perm is not a valid npm option`

Siden vi gjør dette i Dockerfile:
```
RUN npm config set unsafe-perm true \
    && npm install -g express@4.17.1 \
    && npm config set unsafe-perm false
```

Ref: https://github.com/navikt/baseimages/commit/0c0cbfcddb81d0720ba6fe6f806074e1dbd5a3c0