### PR TITLE
Oppgradert appdynamics agent til 23.5.0

### DIFF
--- a/java/appdynamics/Dockerfile
+++ b/java/appdynamics/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_image
 
-FROM appdynamics/java-agent:22.9.2 AS appdynamics
+FROM appdynamics/java-agent:23.5.0 AS appdynamics
 RUN find /opt/appdynamics -type d -name argentoDynamicService -exec rm -rf {} +;
 
 FROM navikt/java:common AS java-common


### PR DESCRIPTION
23.5.0 versjonen inneholder fiks for en kjent feil

> An incorrect hostname gets injected into the agent configuration while using the on-premise Controller.


Fra 23.1.0 er det også støtte for JDK19