### PR TITLE
Added node 18, stopped pushing EOL images.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,7 +36,7 @@ jobs:
   build-legacy-node-express:
     strategy:
       matrix:
-        node: [ '9', '12', '14', '16' ]
+        node: [ '9', '12', '14', '16', '18' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,7 +36,7 @@ jobs:
   build-legacy-node-express:
     strategy:
       matrix:
-        node: [ '9', '12', '14', '16', '18' ]
+        node: [ '16', '18' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
@@ -88,7 +88,7 @@ jobs:
   build-temurin:
     strategy:
       matrix:
-        version: [ '8', '11', '17', '18', '19', '20' ]
+        version: [ '8', '11', '17', '20' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
@@ -122,7 +122,7 @@ jobs:
   build-temurin-appd:
     strategy:
       matrix:
-        version: [ '8', '11', '17', '18', '19', '20' ]
+        version: [ '8', '11', '17', '20' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code

--- a/README.md
+++ b/README.md
@@ -15,15 +15,18 @@ This project contains base docker images for use with the NAIS platform.
 
 Available images from **Github Container Registry**:
 * **Java**
-  * Adoptium Temurin 8, 11, 17 - 20 https://adoptium.net/ ([`java`](java)) (ex. `FROM ghcr.io/navikt/baseimages/temurin:17`)
-  * Temurin with appdynamics-support, add -appdynamics suffix. (ex. `FROM ghcr.io/navikt/baseimages/temurin:17-appdynamics`)
-    * Latest Temurin LTS release is 17.
-    * Both temurin and temurin-appdynamics builds are available for `linux/amd64` (Intel) and `linux/arm64` (Apple Silicon) platforms.
-    * NB! The current arm64 build does not take `/dumb-init` into consideration thus this needs to be emulated at rutime on Apple machines with Apple Silicon processors.
+  * Adoptium Temurin 8, 11, 17 & 20 https://adoptium.net/ ([`java`](java)) (`18 & 19 not updated`)
+    * Ex. `FROM ghcr.io/navikt/baseimages/temurin:17`
+  * Temurin with appdynamics-support, add -appdynamics suffix.
+    * Ex. `FROM ghcr.io/navikt/baseimages/temurin:17-appdynamics`
+  * Both temurin and temurin-appdynamics builds are available for `linux/amd64` (Intel) and `linux/arm64` (Apple Silicon) platforms.
+  * NB! The current arm64 build does not take `/dumb-init` into consideration thus this needs to be emulated at rutime on Apple machines with Apple Silicon processors.
 * **Node**
-  * Node 16 and 18 with Express 4 ([`node-express`](node-express)) (`9, 12 & 14 not updated`) (ex. `FROM ghcr.io/navikt/baseimages/node-express:18`)
+  * Node 16 and 18 with Express 4 ([`node-express`](node-express)) (`9, 12 & 14 not updated`)
+    * Ex. `FROM ghcr.io/navikt/baseimages/node-express:18`
 * **Python**
-  * Python 3.8 - 3.11 ([`python`](python)) (`3.7 not updated`) (ex. `FROM ghcr.io/navikt/baseimages/python:3.11`)
+  * Python 3.8 - 3.11 ([`python`](python)) (`3.7 not updated`)
+    * Ex. `FROM ghcr.io/navikt/baseimages/python:3.11`
 
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Available images from **Github Container Registry**:
     * Both temurin and temurin-appdynamics builds are available for `linux/amd64` (Intel) and `linux/arm64` (Apple Silicon) platforms.
     * NB! The current arm64 build does not take `/dumb-init` into consideration thus this needs to be emulated at rutime on Apple machines with Apple Silicon processors.
 * **Node**
-  * Node 9, 12, 14 and 16 with Express 4 ([`node-express`](node-express)) (`9, 12 & 14 are deprecated`) (ex. `FROM ghcr.io/navikt/baseimages/node-express:16`)
+  * Node 16 and 18 with Express 4 ([`node-express`](node-express)) (`9, 12 & 14 not updated`) (ex. `FROM ghcr.io/navikt/baseimages/node-express:18`)
 * **Python**
-  * Python 3.7 - 3.11 ([`python`](python)) (ex. `FROM ghcr.io/navikt/baseimages/python:3.11`)
+  * Python 3.8 - 3.11 ([`python`](python)) (`3.7 not updated`) (ex. `FROM ghcr.io/navikt/baseimages/python:3.11`)
 
 
 ## Getting Started

--- a/node-express/Dockerfile
+++ b/node-express/Dockerfile
@@ -14,8 +14,7 @@ COPY run-node.sh /run-script.sh
 WORKDIR /var/server
 
 RUN npm config set unsafe-perm true \
-    && npm install -g express@4.17.1 \
-    && npm config set unsafe-perm false
+    && npm install -g express@4.17.1
 
 RUN /setup-apprunner.sh /var/server
 USER apprunner

--- a/node-express/Dockerfile
+++ b/node-express/Dockerfile
@@ -13,8 +13,7 @@ COPY run-node.sh /run-script.sh
 
 WORKDIR /var/server
 
-RUN npm config set unsafe-perm true \
-    && npm install -g express@4.17.1
+RUN npm install -g express@4.17.1
 
 RUN /setup-apprunner.sh /var/server
 USER apprunner


### PR DESCRIPTION
* Removed unsafe-perm workaround in node docker images that blocked node18. Info here: https://www.vinayraghu.com/blog/npm-unsafe-perm
* Stopped building & pushing images that EOL and won't receive updates anyway.
* Updated readme