### PR TITLE
Revert "Bump appdynamics/java-agent from 24.3.0 to 24.6.0.36087 in /java/appdynamics"

### DIFF
--- a/java/appdynamics/Dockerfile
+++ b/java/appdynamics/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_image
 
-FROM appdynamics/java-agent:24.6.0.36087 AS appdynamics
+FROM appdynamics/java-agent:24.3.0 AS appdynamics
 USER root
 RUN find /opt/appdynamics -type d -name argentoDynamicService -exec rm -rf {} +;
 


### PR DESCRIPTION
Reverts navikt/baseimages#169

Oppdatering skaper trøbbel med TLS integrasjon mot IBM MQ brokeren med JMS.

